### PR TITLE
modified example env file + added two additional import paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# local env file
+env.local.sh

--- a/env.local-sample
+++ b/env.local-sample
@@ -6,5 +6,7 @@ export BRV_CERT_FILE=tls.cert
 export BRV_KEY_FILE=tls.key
 export BRV_CA_FILE=tls.ca
 
+export PROTOC=protoc
+
 # export TZ=Asia/Tehran
 # export DOWNLOADER="https_proxy=http://127.0.0.1:8118 curl -o"

--- a/proto/generate.go
+++ b/proto/generate.go
@@ -1,4 +1,4 @@
 package proto
 
-//go:generate protoc -I/usr/local/include -I. -I${GOPATH}/src -I${GOPATH}/src/github.com/gengo/grpc-gateway/third_party/googleapis --go_out=Mgoogle/api/annotations.proto=github.com/gengo/grpc-gateway/third_party/googleapis/google/api,plugins=grpc:. common.proto public.proto internal.proto
-//go:generate protoc -I/usr/local/include -I. -I${GOPATH}/src -I${GOPATH}/src/github.com/gengo/grpc-gateway/third_party/googleapis --grpc-gateway_out=logtostderr=true:. common.proto public.proto internal.proto
+//go:generate ${PROTOC} -I${GOPATH}/src/github.com/google/protobuf/src -I${GOPATH}/src/github.com -I/usr/local/include -I. -I${GOPATH}/src -I${GOPATH}/src/github.com/gengo/grpc-gateway/third_party/googleapis --go_out=Mgoogle/api/annotations.proto=github.com/gengo/grpc-gateway/third_party/googleapis/google/api,plugins=grpc:. common.proto public.proto internal.proto
+//go:generate ${PROTOC} -I${GOPATH}/src/github.com/google/protobuf/src -I${GOPATH}/src/github.com -I/usr/local/include -I. -I${GOPATH}/src -I${GOPATH}/src/github.com/gengo/grpc-gateway/third_party/googleapis --grpc-gateway_out=logtostderr=true:. common.proto public.proto internal.proto


### PR DESCRIPTION
Since protobuf 3 is still on beta, "protoc" version is still 2.x.y on a lot
of machines. Added ${PROTOC} to environemts file as a workaround so that
the protoc version 3 binary can be specified manually.

Also added two import paths to protoc command
